### PR TITLE
Fix the identifiers (the rest of cases that were not caught before)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 sudo: false
 
+before_install:
+- git clone https://github.com/eurocris/CERIF-TG-Tools.git ../CERIF-TG-Tools
+- git clone https://github.com/jdvorak001/openaire-cris-validator.git ../openaire-cris-validator
+
 language: java
 
 jdk:
@@ -10,5 +14,4 @@ jdk:
 install: true
 
 script:
-    # this runs two Maven goals: transform and validate
-    - travis_wait mvn test -B
+    - travis_wait ./tools/compile.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ jdk:
 install: true
 
 script:
-    # this runs two Maven goals: transform and validate
-    - travis_wait mvn test -B
+    - travis_wait ./tools/compile.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 sudo: false
 
+before_install:
+- git clone https://github.com/eurocris/CERIF-TG-Tools.git ../CERIF-TG-Tools
+- git clone https://github.com/jdvorak001/openaire-cris-validator.git ../openaire-cris-validator
+
 language: java
 
 jdk:

--- a/conf/openaire-cerif-profile.xml
+++ b/conf/openaire-cerif-profile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<CERIF-profile xmlns="https://w3id.org/cerif/profile" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cflink="https://w3id.org/cerif/annotations#" xsi:schemaLocation="https://w3id.org/cerif/profile ../../../git/CERIF-TG-Tools/src/main/resources/xsd/cerif-profile-definition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<CERIF-profile xmlns="https://w3id.org/cerif/profile" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cflink="https://w3id.org/cerif/annotations#" xsi:schemaLocation="https://w3id.org/cerif/profile ../../CERIF-TG-Tools/CERIF-Model-Tools/src/main/resources/xsd/cerif-profile-definition.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
 	<xs:annotation>
 		<xs:documentation>This is the XML Schema for the OpenAIRE CERIF profile 1.1, 
 			a companion artifact of the OpenAIRE Guidelines for CRIS Managers 1.1 (http://openaire-guidelines-for-cris-managers.readthedocs.io/en/latest/index.html). 
@@ -71,6 +71,11 @@
 		</Entity>
 
 		<Entity uri="https://w3id.org/cerif/model#OrganisationUnit" leaveOut="Parts">
+			<IdentifiersFrom schemaLocation="includes/orgunit-identifiers.xsd">
+				<xs:annotation>
+					<xs:documentation>The orgunit identifiers.</xs:documentation>
+				</xs:annotation>
+			</IdentifiersFrom>
 		</Entity>
 
 		<Entity uri="https://w3id.org/cerif/model#ElectronicAddress">

--- a/conf/openaire-cerif-profile.xml
+++ b/conf/openaire-cerif-profile.xml
@@ -124,7 +124,7 @@
                             <xs:documentation>The flag if Open Access is mandated for this funding</xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="uri" type="xs:anyURI" use="optional" cflink:link="https://w3id.org/cerif/model#Funding_Classification(https://w3id.org/cerif/vocab/OpenAccessMandate)">
+                    <xs:attribute name="uri" type="xs:anyURI" use="optional" cflink:link="https://w3id.org/cerif/model#Funding_Classification(http://roarmap.eprints.org/)">
                         <xs:annotation>
                             <xs:documentation>The Open Access policy that applies to this funding</xs:documentation>
                         </xs:annotation>

--- a/conf/openaire-cerif-profile.xml
+++ b/conf/openaire-cerif-profile.xml
@@ -33,17 +33,17 @@
 					<xs:documentation>OpenAIRE compatibility of the CRIS</xs:documentation>
 				</xs:annotation>
 			</Classification>
-			<xs:element name="WebsiteURL" type="cfString__Type" minOccurs="0" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/ElectronicAddressTypes#Website)">
+			<xs:element name="WebsiteURL" type="cfString__Type" minOccurs="0" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/ElectronicAddressTypes#Website)">
 				<xs:annotation>
 					<xs:documentation>URL of the website of the CRIS</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="OAIPMHBaseURL" type="cfString__Type" minOccurs="0" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/ElectronicAddressTypes#OAI-PMH_Base)">
+			<xs:element name="OAIPMHBaseURL" type="cfString__Type" minOccurs="0" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/ElectronicAddressTypes#OAI-PMH_Base)">
 				<xs:annotation>
 					<xs:documentation>Base URL for the OAI-PMH protocol endpoint of the CRIS</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="SubjectHeadingsURL" type="cfString__Type" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/ElectronicAddressTypes#SubjectHeadings)">
+			<xs:element name="SubjectHeadingsURL" type="cfString__Type" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/IdentifierTypes#URL) https://w3id.org/cerif/model#FederatedIdentifier(https://w3id.org/cerif/vocab/ElectronicAddressTypes#SubjectHeadings)">
 				<xs:annotation>
 					<xs:documentation>The URL where the subject classification used by the CRIS can be obtained (using the HTTP GET)</xs:documentation>
 				</xs:annotation>
@@ -167,7 +167,7 @@
 					<xs:documentation>The event that is covered by this publication (e.g. a report about the event)</xs:documentation>
 				</xs:annotation>
 			</Link>
-			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
+			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
 				<xs:annotation>
 					<xs:documentation>Result outputs that are referenced by this publication</xs:documentation>
 				</xs:annotation>
@@ -190,7 +190,7 @@
                     <xs:documentation>The product identifiers.</xs:documentation>
                 </xs:annotation>
             </IdentifiersFrom>
-			<Link name="GeneratedBy" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultProduct_Equipment(https://w3id.org/cerif/vocab/InfrastructureOutputRelations#Generation)" target="Equipment">
+			<Link name="GeneratedBy" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultProduct_Equipment(https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations#Generation)" target="Equipment">
 				<xs:annotation>
 					<xs:documentation>The equipment that generated this product</xs:documentation>
 				</xs:annotation>
@@ -205,7 +205,7 @@
 					<xs:documentation>The event that is covered by this product (e.g. a video or audio interview about the event)</xs:documentation>
 				</xs:annotation>
 			</Link>
-			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
+			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
 				<xs:annotation>
 					<xs:documentation>Result outputs that are referenced by this product</xs:documentation>
 				</xs:annotation>
@@ -217,18 +217,23 @@
             </xs:element>
 		</Entity>
 
-		<Entity uri="https://w3id.org/cerif/model#ResultPatent" leaveOut="ReferencedBy Parts Identifier">
+		<Entity uri="https://w3id.org/cerif/model#ResultPatent" leaveOut="ReferencedBy Parts">
 			<Classification kind="Type" schema="vocabularies/coar_patent_types.xsd" minOccurs="1" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The type of the patent (currently just one option)</xs:documentation>
 				</xs:annotation>
 			</Classification>
-            <Link name="Predecessor" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/Inter-OutputRelations#Predecessor):1" target="Patent">
+            <IdentifiersFrom schemaLocation="includes/patent-identifiers.xsd">
+                <xs:annotation>
+                    <xs:documentation>The patent identifiers.</xs:documentation>
+                </xs:annotation>
+            </IdentifiersFrom>
+            <Link name="Predecessor" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterPatentRelations#Predecessor):1" target="Patent">
                 <xs:annotation>
                     <xs:documentation>Patents that precede (i.e., have priority over) this patent</xs:documentation>
                 </xs:annotation>
             </Link>
-			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPatent_ResultPublication(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPatent_ResultProduct(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/Inter-OutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
+			<Link name="References" minOccurs="0" maxOccurs="unbounded" cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" target="ResearchOutput__SubstitutionGroupHead">
 				<xs:annotation>
 					<xs:documentation>Result outputs that are referenced by this patent</xs:documentation>
 				</xs:annotation>

--- a/docs/cerif_xml_funding_entity.rst
+++ b/docs/cerif_xml_funding_entity.rst
@@ -101,7 +101,7 @@ Funder
 :Description: The funder or funders
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``Funder`` with embedded XML element ``OrgUnit`` or ``Person``. A ``DisplayName`` may be specified, too.
-:CERIF: the OrganisationUnit_Funding linking entity (`<https://w3id.org/cerif/model#OrganisationUnit_Funding>`_) with the `<https://w3id.org/cerif/vocab/OrganisationFundingEngagements#Funder>`_ semantics
+:CERIF: the OrganisationUnit_Funding linking entity (`<https://w3id.org/cerif/model#OrganisationUnit_Funding>`_) with the `<https://w3id.org/cerif/vocab/OrganisationFundingRoles#Financier>`_ semantics
 
 
 PartOf
@@ -109,7 +109,7 @@ PartOf
 :Description: Chain up to the larger funding that encompasses this funding
 :Use: optional (0..1)
 :Representation: XML element ``PartOf`` with embedded XML element ``Funding``
-:CERIF: the Funding_Funding linking entity (`<https://w3id.org/cerif/model#Funding_Funding>`_) with the `<https://w3id.org/cerif/vocab/Inter­FundingRelations#Part>`_ semantics (direction :1)
+:CERIF: the Funding_Funding linking entity (`<https://w3id.org/cerif/model#Funding_Funding>`_) with the `<https://w3id.org/cerif/vocab/InterFundingRelations#Part>`_ semantics (direction :1)
 
 
 Duration

--- a/docs/cerif_xml_organisation_entity.rst
+++ b/docs/cerif_xml_organisation_entity.rst
@@ -42,12 +42,91 @@ Name
 
 
 
+RORID
+^^^^^
+:Description: The ROR identifier in case its value is certain or known to be a preferred one.
+:Use: optional (0..1)
+:Representation: XML element ``RORID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``https:\/\/ror\.org\/0[\da-hj-km-np-tv-zA-HJ-KM-NP-TV-Z]{6}\d{2}`` (as per `<https://ror.org/facts/>`_)
+
+
+
+AlternativeRORID
+^^^^^^^^^^^^^^^^
+:Description: The ROR identifiers in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``AlternativeRORID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``https:\/\/ror\.org\/0[\da-hj-km-np-tv-zA-HJ-KM-NP-TV-Z]{6}\d{2}`` (as per `<https://ror.org/facts/>`_)
+
+
+
+GRID
+^^^^
+:Description: The GRID identifier in case its value is certain or known to be a preferred one.
+:Use: optional (0..1)
+:Representation: XML element ``GRID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``grid\.\d{4,}\.[0-9a-f]{1,2}`` (as per `<https://www.wikidata.org/wiki/Property_talk:P2427>`_)
+
+
+
+AlternativeGRID
+^^^^^^^^^^^^^^^
+:Description: The GRID identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``AlternativeGRID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``grid\.\d{4,}\.[0-9a-f]{1,2}`` (as per `<https://www.wikidata.org/wiki/Property_talk:P2427>`_)
+
+
+
+ISNI
+^^^^
+:Description: The ISNI identifier in case its value is certain or known to be a preferred one.
+:Use: optional (0..1)
+:Representation: XML element ``ISNI``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``\d{4} \d{4} \d{4} \d{3}[\dX]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
+
+
+
+AlternativeISNI
+^^^^^^^^^^^^^^^
+:Description: The ISNI identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``AlternativeISNI``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``\d{4} \d{4} \d{4} \d{3}[\dX]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
+
+
+
+FundRefID
+^^^^^^^^^
+:Description: The FundRef Registry Identifier in case its value is certain or known to be a preferred one.
+:Use: optional (0..1)
+:Representation: XML element ``FundRefID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``https:\/\/doi.org\/10\.13039\/\d+`` (as per `<https://www.crossref.org/display-guidelines/>`_ `<https://www.wikidata.org/wiki/Q19822542>`_)
+
+
+
+AlternativeFundRefID
+^^^^^^^^^^^^^^^^^^^^
+:Description: The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.
+:Use: optional, possibly multiple (0..*)
+:Representation: XML element ``AlternativeFundRefID``
+:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Format: regular expression ``https:\/\/doi.org\/10\.13039\/\d+`` (as per `<https://www.crossref.org/display-guidelines/>`_ `<https://www.wikidata.org/wiki/Q19822542>`_)
+
+
+
 Identifier
 ^^^^^^^^^^
-:Description: An identifier of the organisation unit
+:Description: A generic identifier, to be used only if your identifier does not fit in any of the above specific identifier types.
 :Use: optional, possibly multiple (0..*)
-:Representation: XML element ``Identifier`` with mandatory ``type`` attribute
-:CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
+:Representation: XML element ``Identifier``
 
 
 

--- a/docs/cerif_xml_patent_entity.rst
+++ b/docs/cerif_xml_patent_entity.rst
@@ -155,7 +155,7 @@ OriginatesFrom
 ^^^^^^^^^^^^^^
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``OriginatesFrom`` with embedded XML element ``Project`` or ``Funding``
-:CERIF: the Project_ResultPatent linking entity (`<https://w3id.org/cerif/model#Project_ResultPatent>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultPatent_Funding linking entity (`<https://w3id.org/cerif/model#ResultPatent_Funding>`_) with the `<https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator>`_ semantics
+:CERIF: the Project_ResultPatent linking entity (`<https://w3id.org/cerif/model#Project_ResultPatent>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultPatent_Funding linking entity (`<https://w3id.org/cerif/model#ResultPatent_Funding>`_) with the `<https://w3id.org/cerif/vocab/OutputFundingRoles#Originator>`_ semantics
 
 
 Predecessor
@@ -163,7 +163,7 @@ Predecessor
 :Description: Patents that precede (i.e., have priority over) this patent
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``Predecessor`` with embedded XML element ``Patent``
-:CERIF: the ResultPatent_ResultPatent linking entity (`<https://w3id.org/cerif/model#ResultPatent_ResultPatent>`_) with the `<https://w3id.org/cerif/vocab/InterOutputRelations#Predecessor>`_ semantics (direction :1)
+:CERIF: the ResultPatent_ResultPatent linking entity (`<https://w3id.org/cerif/model#ResultPatent_ResultPatent>`_) with the `<https://w3id.org/cerif/vocab/InterPatentRelations#Predecessor>`_ semantics (direction :1)
 
 
 References

--- a/docs/cerif_xml_person_entity.rst
+++ b/docs/cerif_xml_person_entity.rst
@@ -57,8 +57,8 @@ Gender
 :CERIF: the Person.Gender attribute (`<https://w3id.org/cerif/model#Person.Gender>`_)
 :Vocabulary: Genders (sociocultural, not linguistic)
 
-  * **Masculine** (``m``): Man
-  * **Feminine** (``f``): Woman
+  * **Masculine** (``m``): 
+  * **Feminine** (``f``): 
 
 
 

--- a/docs/cerif_xml_person_entity.rst
+++ b/docs/cerif_xml_person_entity.rst
@@ -128,7 +128,7 @@ ISNI
 :Use: optional (0..1)
 :Representation: XML element ``ISNI``
 :CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
-:Format: regular expression ``[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
+:Format: regular expression ``\d{4} \d{4} \d{4} \d{3}[\dX]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
 
 
 
@@ -138,7 +138,7 @@ AlternativeISNI
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``AlternativeISNI``
 :CERIF: the FederatedIdentifier entity (`<https://w3id.org/cerif/model#FederatedIdentifier>`_)
-:Format: regular expression ``[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
+:Format: regular expression ``\d{4} \d{4} \d{4} \d{3}[\dX]`` (as per `<https://www.wikidata.org/wiki/Property:P213>`_)
 
 
 

--- a/docs/cerif_xml_product_entity.rst
+++ b/docs/cerif_xml_product_entity.rst
@@ -51,7 +51,7 @@ Language
 :Description: The language or languages of the product, if applicable. Please use the IETF language tags as described in the IETF BCP 47 document.
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``Language``
-:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<https://w3id.org/cerif/vocab/LanguageTags>`_ semantics
+:CERIF: the ResultProduct_Classification linking entity (`<https://w3id.org/cerif/model#ResultProduct_Classification>`_) with the `<http://publications.europa.eu/resource/authority/language>`_ semantics
 
 
 Name
@@ -187,7 +187,7 @@ OriginatesFrom
 ^^^^^^^^^^^^^^
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``OriginatesFrom`` with embedded XML element ``Project`` or ``Funding``
-:CERIF: the Project_ResultProduct linking entity (`<https://w3id.org/cerif/model#Project_ResultProduct>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultProduct_Funding linking entity (`<https://w3id.org/cerif/model#ResultProduct_Funding>`_) with the `<https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator>`_ semantics
+:CERIF: the Project_ResultProduct linking entity (`<https://w3id.org/cerif/model#Project_ResultProduct>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultProduct_Funding linking entity (`<https://w3id.org/cerif/model#ResultProduct_Funding>`_) with the `<https://w3id.org/cerif/vocab/OutputFundingRoles#Originator>`_ semantics
 
 
 GeneratedBy
@@ -195,7 +195,7 @@ GeneratedBy
 :Description: The equipment that generated this product
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``GeneratedBy`` with embedded XML element ``Equipment``
-:CERIF: the ResultProduct_Equipment linking entity (`<https://w3id.org/cerif/model#ResultProduct_Equipment>`_) with the `<https://w3id.org/cerif/vocab/InfrastructureOutputRelations#Generation>`_ semantics
+:CERIF: the ResultProduct_Equipment linking entity (`<https://w3id.org/cerif/model#ResultProduct_Equipment>`_) with the `<https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations#Generation>`_ semantics
 
 
 PresentedAt

--- a/docs/cerif_xml_publication_entity.rst
+++ b/docs/cerif_xml_publication_entity.rst
@@ -86,7 +86,7 @@ Language
 :Description: The language of the publication. Please use the IETF language tags as described in the IETF BCP 47 document.
 :Use: optional (0..1)
 :Representation: XML element ``Language``
-:CERIF: the ResultPublication_Classification linking entity (`<https://w3id.org/cerif/model#ResultPublication_Classification>`_) with the `<https://w3id.org/cerif/vocab/LanguageTags>`_ semantics
+:CERIF: the ResultPublication_Classification linking entity (`<https://w3id.org/cerif/model#ResultPublication_Classification>`_) with the `<http://publications.europa.eu/resource/authority/language>`_ semantics
 
 
 Title
@@ -413,7 +413,7 @@ OriginatesFrom
 ^^^^^^^^^^^^^^
 :Use: optional, possibly multiple (0..*)
 :Representation: XML element ``OriginatesFrom`` with embedded XML element ``Project`` or ``Funding``
-:CERIF: the Project_ResultPublication linking entity (`<https://w3id.org/cerif/model#Project_ResultPublication>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultPublication_Funding linking entity (`<https://w3id.org/cerif/model#ResultPublication_Funding>`_) with the `<https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator>`_ semantics
+:CERIF: the Project_ResultPublication linking entity (`<https://w3id.org/cerif/model#Project_ResultPublication>`_) with the `<https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator>`_ semantics; the ResultPublication_Funding linking entity (`<https://w3id.org/cerif/model#ResultPublication_Funding>`_) with the `<https://w3id.org/cerif/vocab/OutputFundingRoles#Originator>`_ semantics
 
 
 PresentedAt

--- a/samples/openaire_cerif_xml_example_fundings.xml
+++ b/samples/openaire_cerif_xml_example_fundings.xml
@@ -30,7 +30,7 @@
 						<OrgUnit id="310001">
 							<Acronym>EC</Acronym>
 							<Name xml:lang="en">European Commission</Name>
-							<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+							<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 						</OrgUnit>
 					</Funder>
 					<Duration startDate="2007-01-01" endDate="2013-12-31" />
@@ -57,7 +57,7 @@
 						<OrgUnit id="310001">
 							<Acronym>EC</Acronym>
 							<Name xml:lang="en">European Commission</Name>
-							<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+							<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 						</OrgUnit>
 					</Funder>
 					<PartOf>

--- a/samples/openaire_cerif_xml_example_orgunits.xml
+++ b/samples/openaire_cerif_xml_example_orgunits.xml
@@ -102,7 +102,7 @@
 		            <Name xml:lang="fi">Euroopan komissio</Name>
 		            <Name xml:lang="sv">Europeiska kommissionen</Name>
 		            <Name xml:lang="hr">Europska komisija</Name>
-					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+					<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 					<Identifier type="">https://europa.eu/</Identifier><!-- FIXME -->
 				</OrgUnit>
 			</metadata>

--- a/samples/openaire_cerif_xml_example_orgunits.xml
+++ b/samples/openaire_cerif_xml_example_orgunits.xml
@@ -51,7 +51,7 @@
 					<Acronym>EKT</Acronym>
 					<Name xml:lang="en" trans="h">National Documentation Centre</Name>
 					<Name xml:lang="el">Εθνικό Κέντρο Τεκμηρίωσης</Name>
-					<Identifier type="">http://www.ekt.gr</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.ekt.gr</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -65,7 +65,7 @@
 				<OrgUnit xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="312348">
 					<Acronym>UKOLN</Acronym>
 					<Name xml:lang="en">UKOLN</Name>
-					<Identifier type="">http://www.ukoln.ac.uk</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.ukoln.ac.uk</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>

--- a/samples/openaire_cerif_xml_example_orgunits.xml
+++ b/samples/openaire_cerif_xml_example_orgunits.xml
@@ -20,7 +20,7 @@
 					<Acronym>NKUA</Acronym>
 					<Name xml:lang="el">ΕΘΝΙΚΟ ΚΑΙ ΚΑΠΟΔΙΣΤΡΙΑΚΟ ΠΑΝΕΠΙΣΤΗΜΙΟ ΑΘΗΝΩΝ</Name>
 					<Name xml:lang="en" trans="h">NATIONAL AND KAPODISTRIAN UNIVERSITY OF ATHENS</Name>
-					<Identifier type="">http://www.uoa.gr</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.uoa.gr</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -36,7 +36,7 @@
 					<Acronym>CNR</Acronym>
 					<Name xml:lang="it">CONSIGLIO NAZIONALE DELLE RICERCHE</Name>
 					<Name xml:lang="en" trans="h">NATIONAL RESEARCH COUNCIL</Name>
-					<Identifier type="">http://www.cnr.it</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.cnr.it</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -103,7 +103,7 @@
 		            <Name xml:lang="sv">Europeiska kommissionen</Name>
 		            <Name xml:lang="hr">Europska komisija</Name>
 					<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
-					<Identifier type="">https://europa.eu/</Identifier><!-- FIXME -->
+					<ElectronicAddress>https://europa.eu/</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>

--- a/samples/openaire_cerif_xml_example_orgunits.xml
+++ b/samples/openaire_cerif_xml_example_orgunits.xml
@@ -20,7 +20,7 @@
 					<Acronym>NKUA</Acronym>
 					<Name xml:lang="el">ΕΘΝΙΚΟ ΚΑΙ ΚΑΠΟΔΙΣΤΡΙΑΚΟ ΠΑΝΕΠΙΣΤΗΜΙΟ ΑΘΗΝΩΝ</Name>
 					<Name xml:lang="en" trans="h">NATIONAL AND KAPODISTRIAN UNIVERSITY OF ATHENS</Name>
-					<Identifier type="">http://www.uoa.gr</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.uoa.gr</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -36,7 +36,7 @@
 					<Acronym>CNR</Acronym>
 					<Name xml:lang="it">CONSIGLIO NAZIONALE DELLE RICERCHE</Name>
 					<Name xml:lang="en" trans="h">NATIONAL RESEARCH COUNCIL</Name>
-					<Identifier type="">http://www.cnr.it</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.cnr.it</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -51,7 +51,7 @@
 					<Acronym>EKT</Acronym>
 					<Name xml:lang="en" trans="h">National Documentation Centre</Name>
 					<Name xml:lang="el">Εθνικό Κέντρο Τεκμηρίωσης</Name>
-					<Identifier type="">http://www.ekt.gr</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.ekt.gr</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -65,7 +65,7 @@
 				<OrgUnit xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="312348">
 					<Acronym>UKOLN</Acronym>
 					<Name xml:lang="en">UKOLN</Name>
-					<Identifier type="">http://www.ukoln.ac.uk</Identifier><!-- FIXME -->
+					<ElectronicAddress>http://www.ukoln.ac.uk</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>
@@ -103,7 +103,7 @@
 		            <Name xml:lang="sv">Europeiska kommissionen</Name>
 		            <Name xml:lang="hr">Europska komisija</Name>
 					<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
-					<Identifier type="">https://europa.eu/</Identifier><!-- FIXME -->
+					<ElectronicAddress>https://europa.eu/</ElectronicAddress>
 				</OrgUnit>
 			</metadata>
 		</record>

--- a/samples/openaire_cerif_xml_example_patents.xml
+++ b/samples/openaire_cerif_xml_example_patents.xml
@@ -94,7 +94,7 @@
 				<setSpec>openaire_cris_patents</setSpec>
 			</header>
 			<metadata>
-				<Patent xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="712179"><!-- MEDICAL DEVICE, IN PARTICULAR FOR THE SEPARATION OF A FLUID -->
+				<Patent xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Patents/712179"><!-- MEDICAL DEVICE, IN PARTICULAR FOR THE SEPARATION OF A FLUID -->
 					<!--https://worldwide.espacenet.com/publicationDetails/biblio?FT=D&date=20150521&DB=EPODOC&locale=en_EP&CC=WO&NR=2015071852A2&KC=A2&ND=4-->
 					<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Patent_Types">http://purl.org/coar/resource_type/c_15cd</Type>
 					<Title xml:lang="en">MEDICAL DEVICE, IN PARTICULAR FOR THE SEPARATION OF A FLUID</Title>

--- a/samples/openaire_cerif_xml_example_projects.xml
+++ b/samples/openaire_cerif_xml_example_projects.xml
@@ -15,7 +15,7 @@
 				<setSpec>openaire_cris_projects</setSpec>
 			</header>
 			<metadata>
-				<Project xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="112345"><!-- OpenAIREplus -->
+				<Project xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Projects/112345"><!-- OpenAIREplus -->
 					<Acronym>OpenAIREplus</Acronym>
 					<Title xml:lang="en">2nd-Generation Open Access Infrastructure for Research in Europe</Title>
 					<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#ProjectReference">283595</Identifier>

--- a/samples/openaire_cerif_xml_example_projects.xml
+++ b/samples/openaire_cerif_xml_example_projects.xml
@@ -43,7 +43,7 @@
 							<OrgUnit id="310001">
 								<Acronym>EC</Acronym>
 								<Name xml:lang="en">European Commission</Name>
-								<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+								<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 							</OrgUnit>
 						</By>
 						<As>
@@ -127,7 +127,7 @@
 							<OrgUnit id="310001">
 								<Acronym>EC</Acronym>
 								<Name xml:lang="en">European Commission</Name>
-								<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+								<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 							</OrgUnit>
 						</By>
 						<As>
@@ -203,7 +203,7 @@
 							<OrgUnit id="310001">
 								<Acronym>EC</Acronym>
 								<Name xml:lang="en">European Commission</Name>
-								<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+								<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 							</OrgUnit>
 						</By>
 						<As>

--- a/samples/openaire_cerif_xml_example_projects.xml
+++ b/samples/openaire_cerif_xml_example_projects.xml
@@ -194,7 +194,7 @@
 								<Acronym>CNR</Acronym>
 								<Name xml:lang="it">CONSIGLIO NAZIONALE DELLE RICERCHE</Name>
 								<Name xml:lang="en" trans="h">NATIONAL RESEARCH COUNCIL</Name>
-								<Identifier type="">http://www.cnr.it</Identifier><!-- FIXME -->
+								<ElectronicAddress>http://www.cnr.it</ElectronicAddress>
 							</OrgUnit>
 						</Partner>
 					</Consortium>

--- a/samples/openaire_cerif_xml_example_publications.xml
+++ b/samples/openaire_cerif_xml_example_publications.xml
@@ -155,7 +155,9 @@
 				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="894490"><!-- Int J Digital Curation -->
 					<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">http://purl.org/coar/resource_type/c_0640<!-- journal --></Type>
 					<Title xml:lang="en">The International Journal of Digital Curation</Title>
+					<NameAbbreviation xml:lang="en">IJDC</NameAbbreviation>
 					<ISSN>1746-8256</ISSN>
+					<ZDB-ID>2266735-0</ZDB-ID>
 					<Access xmlns="http://purl.org/coar/access_right">http://purl.org/coar/access_right/c_14cb<!-- metadata only access --></Access>
 				</Publication>
 			</metadata>

--- a/samples/openaire_cerif_xml_example_publications.xml
+++ b/samples/openaire_cerif_xml_example_publications.xml
@@ -130,7 +130,7 @@
 									<OrgUnit id="310001">
 										<Acronym>EC</Acronym>
 										<Name xml:lang="en">European Commission</Name>
-										<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+										<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 									</OrgUnit>
 								</By>
 								<As>
@@ -201,8 +201,8 @@
 									<OrgUnit id="310001">
 										<Acronym>EC</Acronym>
 							            <Name xml:lang="en">European Commission</Name>
-										<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
-			                			</OrgUnit>
+										<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
+			                		</OrgUnit>
 								</By>
 								<As>
 									<Funding id="612352"/><!-- FP7 / Capacities / Research Infrastructures / OpenAIREplus -->
@@ -338,7 +338,7 @@
 									<OrgUnit id="310001">
 										<Acronym>EC</Acronym>
 										<Name xml:lang="en">European Commission</Name>
-										<Identifier type="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID">http://dx.doi.org/10.13039/501100000780</Identifier>
+										<FundRefID>https://doi.org/10.13039/501100000780</FundRefID>
 									</OrgUnit>
 								</By>
 								<As>

--- a/samples/openaire_cerif_xml_example_publications.xml
+++ b/samples/openaire_cerif_xml_example_publications.xml
@@ -152,7 +152,7 @@
 				<setSpec>openaire_cris_publications</setSpec>
 			</header>
 			<metadata>
-				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="894490"><!-- Int J Digital Curation -->
+				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Publications/894490"><!-- Int J Digital Curation -->
 					<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">http://purl.org/coar/resource_type/c_0640<!-- journal --></Type>
 					<Title xml:lang="en">The International Journal of Digital Curation</Title>
 					<ISSN>1746-8256</ISSN>
@@ -168,7 +168,7 @@
 				<setSpec>openaire_cris_publications</setSpec>
 			</header>
 			<metadata>
-				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="894491">
+				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Publications/894491">
 					<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">http://purl.org/coar/resource_type/c_3e5a<!-- contribution to journal --></Type>
 					<Title xml:lang="en">The International Journal of Digital Curation: Special Issue on Open Access Repositories</Title>
 					<PublishedIn>
@@ -220,7 +220,7 @@
 				<setSpec>openaire_cris_publications</setSpec>
 			</header>
 			<metadata>
-				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="4123451">
+				<Publication xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Publications/4123451">
 					<Type xmlns="https://www.openaire.eu/cerif-profile/vocab/COAR_Publication_Types">http://purl.org/coar/resource_type/c_5794<!-- conference paper --></Type>
                     <Language>en</Language>
 					<Title xml:lang="en">The Data Model of the OpenAIRE Scientific Communication e-Infrastructure</Title>

--- a/samples/openaire_oaipmh_example_Identify.xml
+++ b/samples/openaire_oaipmh_example_Identify.xml
@@ -28,7 +28,7 @@
 		</description>
 
 		<description>
-			<Service xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="8123451"><!-- cris.example.org -->
+			<Service xmlns="https://www.openaire.eu/cerif-profile/1.1/" id="Services/8123451"><!-- cris.example.org -->
 				<Compatibility xmlns="https://www.openaire.eu/cerif-profile/vocab/OpenAIRE_Service_Compatibility">https://www.openaire.eu/cerif-profile/vocab/OpenAIRE_Service_Compatibility#1.1</Compatibility>
                 <Acronym>cris.example.org</Acronym>
 				<Name xml:lang="en">The example CRIS</Name>

--- a/schemas/includes/cerif-base-identifiers.xsd
+++ b/schemas/includes/cerif-base-identifiers.xsd
@@ -98,5 +98,26 @@
             </xs:simpleType>
         </xs:union>
     </xs:simpleType>
+    
+    <xs:complexType name="ISNI__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the ISNI identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="01ceb044-45b0-4ac9-91c1-d72edc5c9ed8">
+					<cf:Name xml:lang="en">The ISNI identifier</cf:Name>
+					<cf:Description xml:lang="en">The identifiers assigned to persons, legal entities and other named objects.  See http://www.isni.org/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="\d{4} \d{4} \d{4} \d{3}[\dX]">
+					<xs:annotation>
+						<xs:documentation source="https://www.wikidata.org/wiki/Property:P213"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
 
 </xs:schema>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -61,7 +61,7 @@
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistryID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -115,7 +115,7 @@
 			<xs:appinfo>
 				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
 					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
-					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+					<cf:Description xml:lang="en">The service of registering research objects and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
 				</cf:Service>
 			</xs:appinfo>
 		</xs:annotation>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -85,6 +85,13 @@
 			</xs:element>
  -->
 
+			<!-- the generic identifier -->
+			<xs:element name="Identifier" type="cfGenericIdentifier__Type" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>A generic identifier, to be used only if your identifier does not fit in any of the above specific identifier types.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
 		</xs:sequence>
 	</xs:group>
 

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -115,7 +115,7 @@
 			<xs:appinfo>
 				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
 					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
-					<cf:Description xml:lang="en">The service of registering research objects and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
 				</cf:Service>
 			</xs:appinfo>
 		</xs:annotation>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cf="urn:xmlns:org.eurocris.cerif" xmlns:cflink="https://w3id.org/cerif/annotations#"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" xml:lang="en"
+	xsi:schemaLocation="http://www.w3.org/2001/XMLSchema https://www.w3.org/2001/XMLSchema.xsd">
+	<xs:annotation>
+		<xs:documentation>This is the XML Schema component for the OpenAIRE CERIF profile 1.1 which specifies the admissible organisation units identifiers.
+			For further description please see the main schema file.
+			This work is licensed under a Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0/).
+		</xs:documentation>
+	</xs:annotation>
+	
+	 <xs:include schemaLocation="../includes/cerif-base-identifiers.xsd">
+        <xs:annotation>
+            <xs:documentation>The basic types of identifiers for use with schemas.</xs:documentation>
+        </xs:annotation>
+    </xs:include>
+
+	<xs:include schemaLocation="../includes/cerif-commons.xsd">
+		<xs:annotation>
+			<xs:documentation>The common building blocks for any CERIF XML Schema.</xs:documentation>
+		</xs:annotation>
+	</xs:include>
+
+	<xs:group name="OrgUnitIdentifiers__Group">
+		<xs:sequence>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR" minOccurs="0" name="ROR" type="ROR__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ROR identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeROR" type="ROR__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ROR identifiers in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#GRID" minOccurs="0" name="GRID" type="GRID__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The GRID identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#GRID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeGRID" type="GRID__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The GRID identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI" minOccurs="0" name="ISNI" type="ISNI__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ISNI identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ISNI https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeISNI" type="ISNI__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The ISNI identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry" minOccurs="0" name="FundRefRegistry" type="FundRefRegistry__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefRegistry" type="FundRefRegistry__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			
+<!-- A skeleton for contributing new identifier types
+			## ideally please submit a GitHub pull request with branch called 'add-XXX'
+			## but we will welcome your contribution no matter how you choose to communicate it to us
+			##
+			## Part one: the elements: first the straight one, then the alternative one
+			## @cflink:link: please replace UUU with a fitting URL that represents the identifier scheme
+			<xs:element cflink:identifier="true" cflink:link="UUU" minOccurs="0" name="XXX" type="XXX__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The XXX identifier in case its value is certain or known to be a preferred one.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element cflink:identifier="true" cflink:link="UUU https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="XXX" type="XXX__Type">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">The XXX identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+ -->
+
+		</xs:sequence>
+	</xs:group>
+
+	<xs:complexType name="ROR__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the ROR identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="98bdad67-6967-40f4-81a6-0fec9cc49705">
+					<cf:Name xml:lang="en">The ROR identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://ror.org/about for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="https:\/\/ror\.org\/0[\da-hj-km-np-tv-zA-HJ-KM-NP-TV-Z]{6}\d{2}">
+					<xs:annotation>
+						<xs:documentation source="https://ror.org/facts/"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+
+	<xs:complexType name="GRID__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the GRID identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="7d46009d-cf86-494d-9f48-a24dbdd11941">
+					<cf:Name xml:lang="en">The GRID identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering research organizations and assigning identifiers to them. See https://www.grid.ac/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="grid\.\d{4,}\.[0-9a-f]{1,2}">
+					<xs:annotation>
+						<xs:documentation source="https://www.wikidata.org/wiki/Property_talk:P2427"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>						
+
+	<xs:complexType name="FundRefRegistry__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the FundRef Registry Identifier</xs:documentation>
+			<xs:appinfo>
+				<cf:Service id="a5aefe76-9cf5-4fab-adb5-52a464884387">
+					<cf:Name xml:lang="en">The FundRef Registry Identifier</cf:Name>
+					<cf:Description xml:lang="en">The service of registering funders and assigning identifiers to them. See https://www.crossref.org/services/funder-registry/ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				<xs:pattern value="https:\/\/doi.org\/10\.13039\/\d+">
+					<xs:annotation>
+						<xs:documentation source="https://www.crossref.org/display-guidelines/"/>
+						<xs:documentation source="https://www.wikidata.org/wiki/Q19822542"/>
+					</xs:annotation>
+				</xs:pattern>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+
+<!-- A skeleton for contributing new identifier types
+			## Part two: the XML Schema type for the identifiers
+	<xs:complexType name="XXX__Type">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">The XML Schema type for the XXX identifier</xs:documentation>
+			<xs:appinfo>
+				## @id: please generate a fresh Version 4 UUID (e.g. through the 'uuidgen | tr A-F a-f' linux or macOS commands or online at https://www.uuidgenerator.net/version4)
+				<cf:Service id="">
+					## please keep the cf:Name equal to the xs:documentation above (dropping the leading "The XML Schema type for "), per @xml:lang
+					<cf:Name xml:lang="en">The XXX identifier</cf:Name>
+					## please provide a short description of the scope of the identifier service and supply a pointer to a webpage with more details
+					<cf:Description xml:lang="en">The service of registering YYY and assigning identifiers to them.  See ZZZ for more details.</cf:Description>
+				</cf:Service>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="cfString__Type">
+				## please supply a regular expression (in @value) the values shall match
+				<xs:pattern value="">
+					<xs:annotation>
+						## and document (in @source) where you got it from
+						<xs:documentation source=""/>
+					</xs:annotation>
+				</xs:pattern>
+				## or at least specify (in @value) the maximum length of the admissible values of the identifier
+				<xs:maxLength value=""/>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+ -->
+
+</xs:schema>

--- a/schemas/includes/orgunit-identifiers.xsd
+++ b/schemas/includes/orgunit-identifiers.xsd
@@ -23,12 +23,12 @@
 	<xs:group name="OrgUnitIdentifiers__Group">
 		<xs:sequence>
 
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR" minOccurs="0" name="ROR" type="ROR__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#RORID" minOccurs="0" name="RORID" type="RORID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The ROR identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#ROR https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeROR" type="ROR__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#RORID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeRORID" type="RORID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The ROR identifiers in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -56,12 +56,12 @@
 				</xs:annotation>
 			</xs:element>
 
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry" minOccurs="0" name="FundRefRegistry" type="FundRefRegistry__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefID" minOccurs="0" name="FundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case its value is certain or known to be a preferred one.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistry https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefRegistry" type="FundRefRegistry__Type">
+			<xs:element cflink:identifier="true" cflink:link="https://w3id.org/cerif/vocab/IdentifierTypes#FundRefRegistryID https://w3id.org/cerif/vocab/IdentifierValueMode#Alternative" minOccurs="0" maxOccurs="unbounded" name="AlternativeFundRefID" type="FundRefID__Type">
 				<xs:annotation>
 					<xs:documentation xml:lang="en">The FundRef Registry Identifier in case the value is not certain, e.g. because there is a conflicting statement with a different value. This can also represent deprecated identifiers/profiles that have been merged into a single, current one that is preferred.</xs:documentation>
 				</xs:annotation>
@@ -88,7 +88,7 @@
 		</xs:sequence>
 	</xs:group>
 
-	<xs:complexType name="ROR__Type">
+	<xs:complexType name="RORID__Type">
 		<xs:annotation>
 			<xs:documentation xml:lang="en">The XML Schema type for the ROR identifier</xs:documentation>
 			<xs:appinfo>
@@ -130,7 +130,7 @@
 		</xs:simpleContent>
 	</xs:complexType>						
 
-	<xs:complexType name="FundRefRegistry__Type">
+	<xs:complexType name="FundRefID__Type">
 		<xs:annotation>
 			<xs:documentation xml:lang="en">The XML Schema type for the FundRef Registry Identifier</xs:documentation>
 			<xs:appinfo>

--- a/schemas/includes/person-identifiers.xsd
+++ b/schemas/includes/person-identifiers.xsd
@@ -8,6 +8,12 @@
 		</xs:documentation>
 	</xs:annotation>
 
+	 <xs:include schemaLocation="../includes/cerif-base-identifiers.xsd">
+        <xs:annotation>
+            <xs:documentation>The basic types of identifiers for use with schemas.</xs:documentation>
+        </xs:annotation>
+    </xs:include>
+	
 	<xs:include schemaLocation="../includes/cerif-commons.xsd">
 		<xs:annotation>
 			<xs:documentation>The common building blocks for any CERIF XML Schema.</xs:documentation>
@@ -150,27 +156,6 @@
 				<xs:pattern value="[0-9]{10,11}">
 					<xs:annotation>
 						<xs:documentation source="https://www.wikidata.org/wiki/Property:P1153"/>
-					</xs:annotation>
-				</xs:pattern>
-			</xs:restriction>
-		</xs:simpleContent>
-	</xs:complexType>
-
-	<xs:complexType name="ISNI__Type">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">The XML Schema type for the ISNI identifier</xs:documentation>
-			<xs:appinfo>
-				<cf:Service id="01ceb044-45b0-4ac9-91c1-d72edc5c9ed8">
-					<cf:Name xml:lang="en">The ISNI identifier</cf:Name>
-					<cf:Description xml:lang="en">The identifiers assigned to persons, legal entities and other named objects.  See http://www.isni.org/ for more details.</cf:Description>
-				</cf:Service>
-			</xs:appinfo>
-		</xs:annotation>
-		<xs:simpleContent>
-			<xs:restriction base="cfString__Type">
-				<xs:pattern value="[0-9]{4} [0-9]{4} [0-9]{4} [0-9]{3}[0-9X]">
-					<xs:annotation>
-						<xs:documentation source="https://www.wikidata.org/wiki/Property:P213"/>
 					</xs:annotation>
 				</xs:pattern>
 			</xs:restriction>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -819,7 +819,7 @@ This entity typically represents the granularity level of a single published ite
 							<!-- any class scheme of the 'status' character -->
 						</xs:element>
 
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPublication(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPublication_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPublication(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPublication_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">
@@ -991,7 +991,7 @@ Source: Wikipedia
 						
 						<!-- TODO -->
 						
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPatent(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPatent_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPatent(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPatent_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">
@@ -1139,7 +1139,7 @@ This includes:
 
 						
 
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultProduct(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultProduct_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultProduct(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultProduct_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -37,6 +37,12 @@
 </xs:annotation>
 </xs:include>
 
+	<xs:include schemaLocation="includes/orgunit-identifiers.xsd">
+<xs:annotation>
+<xs:documentation>The orgunit identifiers.</xs:documentation>
+</xs:annotation>
+</xs:include>
+
 	<xs:include schemaLocation="includes/publication-identifiers.xsd">
 <xs:annotation>
 <xs:documentation>The publication identifiers.</xs:documentation>
@@ -217,11 +223,7 @@ In the research information domain Organisation Units typically represents:
 							</xs:annotation>
 						</xs:element>
 						
-						<xs:element cflink:identifier="true" maxOccurs="unbounded" minOccurs="0" name="Identifier" type="cfGenericIdentifier__Type">
-							<xs:annotation>
-								<xs:documentation>An identifier of the organisation unit</xs:documentation>
-							</xs:annotation>
-						</xs:element>
+						<xs:group ref="OrgUnitIdentifiers__Group"/>
 
 						<!-- ... -->
 

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -559,7 +559,7 @@ The Project entity only captures details of the project scope and plan. Informat
 							</xs:annotation>
 						</xs:element>
 						
-						<xs:element cflink:link="https://w3id.org/cerif/model#OrganisationUnit_Funding(https://w3id.org/cerif/vocab/OrganisationFundingEngagements#Funder)" maxOccurs="unbounded" minOccurs="0" name="Funder" type="cfLinkWithDisplayNameToPersonOrOrgUnit__Type">
+						<xs:element cflink:link="https://w3id.org/cerif/model#OrganisationUnit_Funding(https://w3id.org/cerif/vocab/OrganisationFundingRoles#Financier)" maxOccurs="unbounded" minOccurs="0" name="Funder" type="cfLinkWithDisplayNameToPersonOrOrgUnit__Type">
 							<xs:annotation>
 								<xs:documentation>The funder or funders</xs:documentation>
 							</xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -877,7 +877,7 @@ This entity typically represents the granularity level of a single published ite
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this publication</xs:documentation>
 </xs:annotation>
@@ -1018,7 +1018,7 @@ Source: Wikipedia
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this patent</xs:documentation>
 </xs:annotation>
@@ -1196,7 +1196,7 @@ This includes:
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this product</xs:documentation>
 </xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -119,6 +119,7 @@ One Person typically has many of these relationships.
 									<xs:documentation>Genders (sociocultural, not linguistic)</xs:documentation>
 									<xs:appinfo>
 										<cf:ClassScheme id="http://publications.europa.eu/resource/authority/human-sex">
+											<cf:Name xml:lang="en">Genders (sociocultural, not linguistic)</cf:Name>
 										</cf:ClassScheme>
 									</xs:appinfo>
 								</xs:annotation>
@@ -128,6 +129,7 @@ One Person typically has many of these relationships.
 											<xs:documentation>Masculine</xs:documentation>
 											<xs:appinfo>
 												<cf:Class classSchemeId="http://publications.europa.eu/resource/authority/human-sex" id="http://publications.europa.eu/resource/authority/human-sex/MALE">
+													<cf:Term xml:lang="en">Male</cf:Term>
 												</cf:Class>
 											</xs:appinfo>
 										</xs:annotation>
@@ -137,6 +139,7 @@ One Person typically has many of these relationships.
 											<xs:documentation>Feminine</xs:documentation>
 											<xs:appinfo>
 												<cf:Class classSchemeId="http://publications.europa.eu/resource/authority/human-sex" id="http://publications.europa.eu/resource/authority/human-sex/FEMALE">
+													<cf:Term xml:lang="en">Female</cf:Term>
 												</cf:Class>
 											</xs:appinfo>
 										</xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -816,7 +816,7 @@ This entity typically represents the granularity level of a single published ite
 							<!-- any class scheme of the 'status' character -->
 						</xs:element>
 
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPublication(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPublication_Funding(https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPublication(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPublication_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">
@@ -988,7 +988,7 @@ Source: Wikipedia
 						
 						<!-- TODO -->
 						
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPatent(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPatent_Funding(https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultPatent(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultPatent_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">
@@ -1136,7 +1136,7 @@ This includes:
 
 						
 
-						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultProduct(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultProduct_Funding(https://w3id.org/cerif/vocab/Funding_Output_Roles#Originator)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Project_ResultProduct(https://w3id.org/cerif/vocab/ProjectOutputRoles#Originator) https://w3id.org/cerif/model#ResultProduct_Funding(https://w3id.org/cerif/vocab/OutputFundingRoles#Funder)" maxOccurs="unbounded" minOccurs="0" name="OriginatesFrom">
 							<xs:complexType>
 								<xs:complexContent>
 									<xs:extension base="cfLink__BaseType">

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -600,7 +600,7 @@ The Project entity only captures details of the project scope and plan. Informat
 <xs:documentation>The flag if Open Access is mandated for this funding</xs:documentation>
 </xs:annotation>
 </xs:attribute>
-<xs:attribute cflink:link="https://w3id.org/cerif/model#Funding_Classification(https://w3id.org/cerif/vocab/OpenAccessMandate)" name="uri" type="xs:anyURI" use="optional">
+<xs:attribute cflink:link="https://w3id.org/cerif/model#Funding_Classification(http://roarmap.eprints.org/)" name="uri" type="xs:anyURI" use="optional">
 <xs:annotation>
 <xs:documentation>The Open Access policy that applies to this funding</xs:documentation>
 </xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -874,7 +874,7 @@ This entity typically represents the granularity level of a single published ite
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPublication(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this publication</xs:documentation>
 </xs:annotation>
@@ -1000,7 +1000,7 @@ Source: Wikipedia
 							</xs:complexType>
 						</xs:element>
 												
-						<xs:element cflink:link="https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Predecessor):1" maxOccurs="unbounded" minOccurs="0" name="Predecessor">
+						<xs:element cflink:link="https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterPatentRelations#Predecessor):1" maxOccurs="unbounded" minOccurs="0" name="Predecessor">
 <xs:annotation>
 <xs:documentation>Patents that precede (i.e., have priority over) this patent</xs:documentation>
 </xs:annotation>
@@ -1015,7 +1015,7 @@ Source: Wikipedia
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultPatent_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this patent</xs:documentation>
 </xs:annotation>
@@ -1193,7 +1193,7 @@ This includes:
 </xs:complexType>
 </xs:element>
 
-<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Reference):1" maxOccurs="unbounded" minOccurs="0" name="References">
+<xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultProduct(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1 https://w3id.org/cerif/model#ResultProduct_ResultPatent(https://w3id.org/cerif/vocab/InterOutputRelations#Relation):1" maxOccurs="unbounded" minOccurs="0" name="References">
 <xs:annotation>
 <xs:documentation>Result outputs that are referenced by this product</xs:documentation>
 </xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -657,7 +657,7 @@ This entity typically represents the granularity level of a single published ite
 
 						
 
-                        <xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_Classification(https://w3id.org/cerif/vocab/LanguageTags)" minOccurs="0" name="Language" type="cfString__Type">
+                        <xs:element cflink:link="https://w3id.org/cerif/model#ResultPublication_Classification(http://publications.europa.eu/resource/authority/language)" minOccurs="0" name="Language" type="cfString__Type">
                             <xs:annotation>
                                 <xs:documentation>The language of the publication.  Please use the IETF language tags as described in the IETF BCP 47 document.</xs:documentation>
                             </xs:annotation>
@@ -1063,7 +1063,7 @@ This includes:
 						
 						
 
-                        <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(https://w3id.org/cerif/vocab/LanguageTags)" maxOccurs="unbounded" minOccurs="0" name="Language" type="cfString__Type">
+                        <xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Classification(http://publications.europa.eu/resource/authority/language)" maxOccurs="unbounded" minOccurs="0" name="Language" type="cfString__Type">
                             <xs:annotation>
                                 <xs:documentation>The language or languages of the product, if applicable.  Please use the IETF language tags as described in the IETF BCP 47 document.</xs:documentation>
                             </xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -565,7 +565,7 @@ The Project entity only captures details of the project scope and plan. Informat
 							</xs:annotation>
 						</xs:element>
 						
-						<xs:element cflink:link="https://w3id.org/cerif/model#Funding_Funding(https://w3id.org/cerif/vocab/Inter­FundingRelations#Part):1" minOccurs="0" name="PartOf">
+						<xs:element cflink:link="https://w3id.org/cerif/model#Funding_Funding(https://w3id.org/cerif/vocab/InterFundingRelations#Part):1" minOccurs="0" name="PartOf">
 							<xs:annotation>
 								<xs:documentation>Chain up to the larger funding that encompasses this funding</xs:documentation>
 							</xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -1148,7 +1148,7 @@ This includes:
 							</xs:complexType>
 						</xs:element>
 						
-						<xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Equipment(https://w3id.org/cerif/vocab/InfrastructureOutputRelations#Generation)" maxOccurs="unbounded" minOccurs="0" name="GeneratedBy">
+						<xs:element cflink:link="https://w3id.org/cerif/model#ResultProduct_Equipment(https://w3id.org/cerif/vocab/OutputResearchInfrastructureRelations#Generation)" maxOccurs="unbounded" minOccurs="0" name="GeneratedBy">
 <xs:annotation>
 <xs:documentation>The equipment that generated this product</xs:documentation>
 </xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -118,8 +118,7 @@ One Person typically has many of these relationships.
 								<xs:annotation>
 									<xs:documentation>Genders (sociocultural, not linguistic)</xs:documentation>
 									<xs:appinfo>
-										<cf:ClassScheme id="https://w3id.org/cerif/vocab/Genders">
-											<cf:Name xml:lang="en">Genders (sociocultural, not linguistic)</cf:Name>
+										<cf:ClassScheme id="http://publications.europa.eu/resource/authority/human-sex">
 										</cf:ClassScheme>
 									</xs:appinfo>
 								</xs:annotation>
@@ -128,9 +127,7 @@ One Person typically has many of these relationships.
 										<xs:annotation>
 											<xs:documentation>Masculine</xs:documentation>
 											<xs:appinfo>
-												<cf:Class classSchemeId="https://w3id.org/cerif/vocab/Genders" id="https://w3id.org/cerif/vocab/Genders#Masculine">
-													<cf:Term xml:lang="en">Masculine</cf:Term>
-													<cf:Definition xml:lang="en">Man</cf:Definition>
+												<cf:Class classSchemeId="http://publications.europa.eu/resource/authority/human-sex" id="http://publications.europa.eu/resource/authority/human-sex/MALE">
 												</cf:Class>
 											</xs:appinfo>
 										</xs:annotation>
@@ -139,9 +136,7 @@ One Person typically has many of these relationships.
 										<xs:annotation>
 											<xs:documentation>Feminine</xs:documentation>
 											<xs:appinfo>
-												<cf:Class classSchemeId="https://w3id.org/cerif/vocab/Genders" id="https://w3id.org/cerif/vocab/Genders#Feminine">
-													<cf:Term xml:lang="en">Feminine</cf:Term>
-													<cf:Definition xml:lang="en">Woman</cf:Definition>
+												<cf:Class classSchemeId="http://publications.europa.eu/resource/authority/human-sex" id="http://publications.europa.eu/resource/authority/human-sex/FEMALE">
 												</cf:Class>
 											</xs:appinfo>
 										</xs:annotation>

--- a/schemas/openaire-cerif-profile.xsd
+++ b/schemas/openaire-cerif-profile.xsd
@@ -43,17 +43,17 @@
 </xs:annotation>
 </xs:include>
 
-<xs:include schemaLocation="includes/product-identifiers.xsd">
+	<xs:include schemaLocation="includes/patent-identifiers.xsd">
+<xs:annotation>
+<xs:documentation>The patent identifiers.</xs:documentation>
+</xs:annotation>
+</xs:include>
+
+	<xs:include schemaLocation="includes/product-identifiers.xsd">
 <xs:annotation>
 <xs:documentation>The product identifiers.</xs:documentation>
 </xs:annotation>
 </xs:include>
-
-	<xs:include schemaLocation="includes/patent-identifiers.xsd">
-		<xs:annotation>
-			<xs:documentation>The patent identifiers.</xs:documentation>
-		</xs:annotation>
-	</xs:include>
 
 	<xs:import namespace="http://purl.org/coar/access_right" schemaLocation="vocabularies/coar_accessrights.xsd"/>
 

--- a/schemas/scripts/xsd2cerif-rst.xsl
+++ b/schemas/scripts/xsd2cerif-rst.xsl
@@ -201,19 +201,24 @@ Internal Identifier
 	</xsl:template>
 
 	<xsl:function name="cf:formatUrl">
-		<xsl:param name="value" as="xs:string"/>
-		<xsl:choose>
-			<xsl:when test="starts-with( $value, 'http:' ) or starts-with( $value, 'https:' ) or starts-with( $value, 'urn:' )">
-				<xsl:text>`&lt;</xsl:text>
-				<xsl:value-of select="$value"/>
-				<xsl:text>&gt;`_</xsl:text>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:text>``</xsl:text>
-				<xsl:value-of select="$value"/>
-				<xsl:text>``</xsl:text>
-			</xsl:otherwise>
-		</xsl:choose>
+		<xsl:param name="values" as="xs:string+"/>
+		<xsl:for-each select="$values">
+			<xsl:if test="position() &gt; 1">
+				<xsl:text> </xsl:text>
+			</xsl:if>
+			<xsl:choose>
+				<xsl:when test="starts-with( ., 'http:' ) or starts-with( ., 'https:' ) or starts-with( ., 'urn:' )">
+					<xsl:text>`&lt;</xsl:text>
+					<xsl:value-of select="."/>
+					<xsl:text>&gt;`_</xsl:text>
+				</xsl:when>
+				<xsl:otherwise>
+					<xsl:text>``</xsl:text>
+					<xsl:value-of select="."/>
+					<xsl:text>``</xsl:text>
+				</xsl:otherwise>
+			</xsl:choose>
+		</xsl:for-each>
 	</xsl:function>
 
 	<xsl:template match="xs:group[ @ref ]" mode="#all">

--- a/tools/compile.sh
+++ b/tools/compile.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+echo '================================================================================'
+echo '*  Compiling the CERIF-Model-Tools                                             *'
+echo '================================================================================'
+( cd ../CERIF-TG-Tools/CERIF-Model-Tools/ && mvn package )
+
+echo
+echo '================================================================================'
+echo '*  Running the CERIF-Model-Tools                                               *'
+echo '================================================================================'
+java -jar ../CERIF-TG-Tools/CERIF-Model-Tools/target/cerif-model-tools-*.jar -d conf/openaire-cerif-profile.xml -o schemas/openaire-cerif-profile.xsd
+
+echo
+echo '================================================================================'
+echo '*  Validating files and producing documentation sources                        *'
+echo '================================================================================'
+
+# extract the current version from the POM file 
+V=$( xpath <pom.xml -e '/project/version' 2>/dev/null | \
+	 sed -ne '/<version>/s/<\/*version>//gp' )
+
+# place the current version in the documentation config file
+echo >docs/conf.sed "/^release/c\\
+release = '$V'" && \
+sed -f docs/conf.sed docs/conf.py >docs/conf1.py && \
+mv docs/conf1.py docs/conf.py || \
+exit 1
+
+# run the maven script
+mvn -B clean package || \
+exit 2
+
+echo
+echo '================================================================================'
+echo '*  Running the Prototype OpenAIRE Validator                                    *'
+echo '================================================================================'
+( cd ../openaire-cris-validator/ && mvn clean package )


### PR DESCRIPTION
Hello @abollini , there were still some naked numeric IDs left. 
I am sorry, the checking command should have been
```
egrep -o 'id="[^"]*"' samples/openaire_*.xml | sort | uniq -c
```

So I am suggesting the rest of the changes in this PR.
Referential integrity will be satisfied after applying this patch.